### PR TITLE
feat: Implement Admin Mode for teacher authentication

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
+import json
 from pathlib import Path
 
 app = FastAPI(title="Mergington High School API",
@@ -18,6 +19,15 @@ app = FastAPI(title="Mergington High School API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+# Load teachers from JSON file
+def load_teachers():
+    teachers_file = Path(__file__).parent / "teachers.json"
+    with open(teachers_file, "r") as f:
+        return json.load(f)
+
+teachers_data = load_teachers()
+teacher_credentials = {teacher["username"]: teacher["password"] for teacher in teachers_data["teachers"]}
 
 # In-memory activity database
 activities = {
@@ -88,9 +98,34 @@ def get_activities():
     return activities
 
 
+@app.post("/login")
+def login(username: str, password: str):
+    """Teacher login endpoint"""
+    if username not in teacher_credentials:
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    
+    if teacher_credentials[username] != password:
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    
+    return {"success": True, "username": username}
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
+def signup_for_activity(activity_name: str, email: str, teacher_username: str = None):
+    """Sign up a student for an activity - requires teacher authentication"""
+    # Only teachers can register students
+    if teacher_username is None:
+        raise HTTPException(
+            status_code=401,
+            detail="Authentication required. Only teachers can register students."
+        )
+    
+    if teacher_username not in teacher_credentials:
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid teacher credentials"
+        )
+    
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +146,21 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
+def unregister_from_activity(activity_name: str, email: str, teacher_username: str = None):
+    """Unregister a student from an activity - requires teacher authentication"""
+    # Only teachers can unregister students
+    if teacher_username is None:
+        raise HTTPException(
+            status_code=401,
+            detail="Authentication required. Only teachers can unregister students."
+        )
+    
+    if teacher_username not in teacher_credentials:
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid teacher credentials"
+        )
+    
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,98 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const userIconBtn = document.getElementById("user-icon-btn");
+  const loginModal = document.getElementById("login-modal");
+  const closeBtn = document.querySelector(".close-btn");
+  const loginForm = document.getElementById("login-form");
+  const logoutBtn = document.getElementById("logout-btn");
+  const loginMessage = document.getElementById("login-message");
+  const modalTitle = document.getElementById("modal-title");
+
+  // Authentication state
+  let currentTeacher = localStorage.getItem("currentTeacher");
+  updateAuthUI();
+
+  // User icon click - toggle login modal
+  userIconBtn.addEventListener("click", () => {
+    loginModal.classList.toggle("hidden");
+  });
+
+  // Close modal when X is clicked
+  closeBtn.addEventListener("click", () => {
+    loginModal.classList.add("hidden");
+  });
+
+  // Close modal when clicking outside of it
+  window.addEventListener("click", (event) => {
+    if (event.target === loginModal) {
+      loginModal.classList.add("hidden");
+    }
+  });
+
+  // Handle login form submission
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const username = document.getElementById("username").value;
+    const password = document.getElementById("password").value;
+
+    try {
+      const response = await fetch(
+        `/login?username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}`,
+        { method: "POST" }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        currentTeacher = username;
+        localStorage.setItem("currentTeacher", username);
+        loginMessage.textContent = `Logged in as ${username}`;
+        loginMessage.className = "success";
+        loginForm.reset();
+        updateAuthUI();
+
+        // Hide modal after 1 second
+        setTimeout(() => {
+          loginModal.classList.add("hidden");
+        }, 1000);
+      } else {
+        loginMessage.textContent = result.detail || "Invalid credentials";
+        loginMessage.className = "error";
+      }
+    } catch (error) {
+      loginMessage.textContent = "Login failed. Please try again.";
+      loginMessage.className = "error";
+      console.error("Login error:", error);
+    }
+  });
+
+  // Handle logout
+  logoutBtn.addEventListener("click", () => {
+    currentTeacher = null;
+    localStorage.removeItem("currentTeacher");
+    loginMessage.textContent = "";
+    loginForm.reset();
+    updateAuthUI();
+  });
+
+  // Update UI based on authentication state
+  function updateAuthUI() {
+    if (currentTeacher) {
+      // Teacher is logged in
+      userIconBtn.textContent = "👨‍🏫";
+      logoutBtn.classList.remove("hidden");
+      loginForm.classList.add("hidden");
+      modalTitle.textContent = `Logged in as: ${currentTeacher}`;
+      loginMessage.textContent = "";
+    } else {
+      // No teacher logged in
+      userIconBtn.textContent = "👤";
+      logoutBtn.classList.add("hidden");
+      loginForm.classList.remove("hidden");
+      modalTitle.textContent = "Login";
+    }
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -30,7 +122,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}" ${!currentTeacher ? 'disabled' : ''}>❌</button></li>`
                   )
                   .join("")}
               </ul>
@@ -73,11 +165,18 @@ document.addEventListener("DOMContentLoaded", () => {
     const activity = button.getAttribute("data-activity");
     const email = button.getAttribute("data-email");
 
+    if (!currentTeacher) {
+      messageDiv.textContent = "You must be logged in as a teacher to unregister students.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      return;
+    }
+
     try {
       const response = await fetch(
         `/activities/${encodeURIComponent(
           activity
-        )}/unregister?email=${encodeURIComponent(email)}`,
+        )}/unregister?email=${encodeURIComponent(email)}&teacher_username=${encodeURIComponent(currentTeacher)}`,
         {
           method: "DELETE",
         }
@@ -114,6 +213,13 @@ document.addEventListener("DOMContentLoaded", () => {
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
 
+    if (!currentTeacher) {
+      messageDiv.textContent = "You must be logged in as a teacher to register students.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      return;
+    }
+
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
 
@@ -121,7 +227,7 @@ document.addEventListener("DOMContentLoaded", () => {
       const response = await fetch(
         `/activities/${encodeURIComponent(
           activity
-        )}/signup?email=${encodeURIComponent(email)}`,
+        )}/signup?email=${encodeURIComponent(email)}&teacher_username=${encodeURIComponent(currentTeacher)}`,
         {
           method: "POST",
         }

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,8 +8,34 @@
   </head>
   <body>
     <header>
-      <h1>Mergington High School</h1>
-      <h2>Extracurricular Activities</h2>
+      <div class="header-content">
+        <div>
+          <h1>Mergington High School</h1>
+          <h2>Extracurricular Activities</h2>
+        </div>
+        <div class="user-menu">
+          <button id="user-icon-btn" class="user-icon-btn">👤</button>
+          <div id="login-modal" class="modal hidden">
+            <div class="modal-content">
+              <span class="close-btn">&times;</span>
+              <h3 id="modal-title">Login</h3>
+              <form id="login-form">
+                <div class="form-group">
+                  <label for="username">Username:</label>
+                  <input type="text" id="username" required />
+                </div>
+                <div class="form-group">
+                  <label for="password">Password:</label>
+                  <input type="password" id="password" required />
+                </div>
+                <button type="submit">Login</button>
+              </form>
+              <div id="login-message"></div>
+              <button id="logout-btn" class="logout-btn hidden">Logout</button>
+            </div>
+          </div>
+        </div>
+      </div>
     </header>
 
     <main>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -22,10 +22,44 @@ header {
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+header .header-content {
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  align-items: flex-start;
 }
 
 header h1 {
   margin-bottom: 10px;
+}
+
+.user-menu {
+  position: relative;
+}
+
+.user-icon-btn {
+  background-color: transparent;
+  color: white;
+  border: 2px solid white;
+  font-size: 20px;
+  padding: 8px 12px;
+  border-radius: 50%;
+  cursor: pointer;
+  transition: all 0.2s;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.user-icon-btn:hover {
+  background-color: rgba(255, 255, 255, 0.2);
 }
 
 main {
@@ -197,4 +231,101 @@ footer {
   margin-top: 30px;
   padding: 20px;
   color: #666;
+}
+
+/* Modal styles */
+.modal {
+  position: fixed;
+  z-index: 1000;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  background-color: white;
+  padding: 20px;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 400px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+  position: relative;
+}
+
+.close-btn {
+  position: absolute;
+  right: 15px;
+  top: 10px;
+  font-size: 28px;
+  font-weight: bold;
+  color: #aaa;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.close-btn:hover {
+  color: #000;
+}
+
+.modal h3 {
+  color: #1a237e;
+  margin-bottom: 20px;
+}
+
+.modal .form-group input {
+  width: 100%;
+  padding: 10px;
+  margin-bottom: 15px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 16px;
+}
+
+.modal button {
+  width: 100%;
+  padding: 10px;
+  margin-top: 10px;
+}
+
+.logout-btn {
+  background-color: #c62828;
+  margin-top: 10px;
+}
+
+.logout-btn:hover {
+  background-color: #e53935;
+}
+
+#login-message {
+  margin-top: 15px;
+  padding: 10px;
+  border-radius: 4px;
+  min-height: 0;
+}
+
+#login-message.success {
+  background-color: #e8f5e9;
+  color: #2e7d32;
+  border: 1px solid #a5d6a7;
+}
+
+#login-message.error {
+  background-color: #ffebee;
+  color: #c62828;
+  border: 1px solid #ef9a9a;
+}
+
+.delete-btn:disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
+  opacity: 0.5;
 }

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,16 @@
+{
+  "teachers": [
+    {
+      "username": "teacher1",
+      "password": "password123"
+    },
+    {
+      "username": "teacher2",
+      "password": "welcome456"
+    },
+    {
+      "username": "admin",
+      "password": "admin789"
+    }
+  ]
+}


### PR DESCRIPTION
## Overview
Implements Admin Mode feature to prevent students from removing each other from activities. Only authenticated teachers can now register and unregister students.

## Changes
- **Backend**: Added teacher authentication via login endpoint
- **Teachers.json**: New file storing teacher credentials
- **Frontend**: Added user icon in header with login modal
- **Authentication**: Login state managed via localStorage
- **Authorization**: Only teachers can modify registrations; students can only view

## Features
✅ User icon (👤) in top-right corner
✅ Click to open login modal
✅ Teachers login with username/password
✅ Students can view participant lists (read-only)
✅ Only teachers can register/unregister students
✅ Persistent login session
✅ Visual feedback (👨‍🏫 when logged in)

## Teacher Credentials
- teacher1 / password123
- teacher2 / welcome456
- admin / admin789

## Testing
1. Load the app without logging in - see all activities but delete buttons are disabled
2. Click user icon → login as teacher1/password123
3. Icon changes to 👨‍🏫
4. Now able to register/unregister students
5. Click user icon → logout
6. Icon changes back to 👤, delete buttons disabled again

Closes #5